### PR TITLE
fix VeertuManage for Veertu Desktop

### DIFF
--- a/include/cli/veertu_manager.py
+++ b/include/cli/veertu_manager.py
@@ -21,7 +21,7 @@ class VeertuManager(object):
             if parser.get('DEFAULT', 'APP_PATH'):
                 self.app = parser.get('DEFAULT', 'APP_PATH')
                 return
-        self.app = self._find_app_name(['Veertu', 'Veertu 2016 Business'])
+        self.app = self._find_app_name(['Veertu', 'Veertu 2016 Business', 'Veertu Desktop'])
         
         
     def _find_app_name(self, options):


### PR DESCRIPTION
Latest version downloaded from veertu.com has a broken VeertuManage because the name of the app is incorrect.