### PR TITLE
Fix for CVE-2015-3214 from qemu upstream

### DIFF
--- a/devices/i8254.c
+++ b/devices/i8254.c
@@ -199,6 +199,12 @@ static uint64_t pit_ioport_read(void *opaque, hwaddr addr,
     PITChannelState *s;
 
     addr &= 3;
+
+    if (addr == 3) {
+        /* Mode/Command register is write only, read is ignored */
+        return 0;
+    }
+
     s = &pit->channels[addr];
     if (s->status_latched) {
         s->status_latched = 0;


### PR DESCRIPTION
Due converting PIO to the new memory read/write api we no longer provide
separate I/O region lenghts for read and write operations. As a result,
reading from PIT Mode/Command register will end with accessing
pit->channels with invalid index.

Fix this by ignoring read from the Mode/Command register.

This is CVE-2015-3214.

Reported-by: Matt Tait <matttait@google.com>
Fixes: 0505bcdec8228d8de39ab1a02644e71999e7c052
Cc: qemu-stable@nongnu.org
Signed-off-by: Petr Matousek <pmatouse@redhat.com>
Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>

Packport of qemu upstream commit d4862a8
Signed-off-by: Evgeny Yakovlev <insoreiges@gmail.com>