### PR TITLE
Added additonal Keycode handling

### DIFF
--- a/window/VmApp.h
+++ b/window/VmApp.h
@@ -16,6 +16,7 @@
  */
 
 #import "VmView.h"
+#import "VmWindow.h"
 #import <VMManager/VMManager.h>
 #import <Cocoa/Cocoa.h>
 
@@ -24,7 +25,7 @@
 @property (nonatomic, readonly) VM* vm;
 @property (nonatomic, readonly) VmView *vmView;
 
-@property NSWindow *normalWindow;
+@property VmWindow *normalWindow;
 @property (strong) NSWindowController *rootController;
 
 - (instancetype)initWithVM:(VM*)vm;

--- a/window/VmApp.m
+++ b/window/VmApp.m
@@ -48,6 +48,10 @@ extern char **gArgv;
 {
     if ([event type] == NSKeyUp && ([event modifierFlags] & NSCommandKeyMask))
         [[self keyWindow] sendEvent:event];
+    else if (event.type == NSEventTypeKeyDown &&
+             [event.charactersIgnoringModifiers isEqualToString:@"\t"] &&
+             (event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask) == NSEventModifierFlagControl)
+        [[self keyWindow] sendEvent:event];
     else
         [super sendEvent:event];
 }
@@ -465,7 +469,7 @@ static void on_vm_created(void* opaque)
         self.observer = [ScopedValueObserver new];
 
         // create a window
-        self.normalWindow = [[NSWindow alloc] initWithContentRect: NSMakeRect(0.0, 0.0, 640.0, 480.0)
+        self.normalWindow = [[VmWindow alloc] initWithContentRect: NSMakeRect(0.0, 0.0, 640.0, 480.0)
                                                    styleMask:NSTitledWindowMask|NSMiniaturizableWindowMask|NSClosableWindowMask|NSResizableWindowMask
                                                      backing:NSBackingStoreNonretained defer:NO];
         if(!self.normalWindow) {
@@ -483,6 +487,7 @@ static void on_vm_created(void* opaque)
         self.vmView = [[VmView alloc] initWithFrame: scrollView.frame pixelFormat:[NSOpenGLView defaultPixelFormat]];
         // the scroll view should have both horizontal
         // and vertical scrollers
+        self.normalWindow.vmview = self.vmView;
         [scrollView setHasVerticalScroller:YES];
         [scrollView setHasHorizontalScroller:YES];
         

--- a/window/VmView.m
+++ b/window/VmView.m
@@ -621,10 +621,21 @@ NSTrackingRectTag trackingRect;
     
     // handle control + alt Key Combos (ctrl+alt is reserved for QEMU)
     if (vmx_console_is_graphic(NULL)) {
-        vmx_mutex_lock_iothread();
-        vmx_input_event_send_key_number(dcl->con, keycode, true);
-        vmx_mutex_unlock_iothread();
-        
+        //remap cmd+<x,c,v> to ctrl+<x,c,v>
+        if(modifiers_state[219] == 1 && (keycode == 45 || keycode == 46 || keycode == 47)){
+            vmx_mutex_lock_iothread();
+            //vmx_input_event_send_key_number(dcl->con, 219, false);
+            vmx_input_event_send_key_number(dcl->con, 29, true);
+            vmx_input_event_send_key_number(dcl->con, keycode, true);
+            vmx_input_event_send_key_number(dcl->con, 29, false);
+            vmx_mutex_unlock_iothread();
+            
+        }
+        else {
+            vmx_mutex_lock_iothread();
+            vmx_input_event_send_key_number(dcl->con, keycode, true);
+            vmx_mutex_unlock_iothread();
+        }
         // handlekeys for Monitor
     } else {
         int keysym = 0;
@@ -719,7 +730,7 @@ NSTrackingRectTag trackingRect;
     }
 
     // release Mouse grab when pressing ctrl+alt
-    if (([event modifierFlags] & NSControlKeyMask) && ([event modifierFlags] & NSAlternateKeyMask))
+    if (([event modifierFlags] & NSControlKeyMask) && ([event modifierFlags] & NSCommandKeyMask))
         [self ungrabMouse];
 }
 

--- a/window/VmWindow.h
+++ b/window/VmWindow.h
@@ -1,0 +1,15 @@
+//
+//  VmWindow.h
+//  vmx
+//
+//  Created by Stephan Kitzler-Walli on 29/08/2017.
+//  Copyright © 2017 Veertu Labs Ltd. All rights reserved.
+//
+
+#import "VmView.h"
+#import <Cocoa/Cocoa.h>
+
+@interface VmWindow : NSWindow
+    @property VmView *vmview;
+@end
+

--- a/window/VmWindow.m
+++ b/window/VmWindow.m
@@ -1,0 +1,25 @@
+//
+//  VmWindow.m
+//  vmx
+//
+//  Created by Stephan Kitzler-Walli on 29/08/2017.
+//  Copyright © 2017 Veertu Labs Ltd. All rights reserved.
+//
+
+#import "VmWindow.h"
+#import "VmView.h"
+#import <Foundation/Foundation.h>
+
+@implementation VmWindow
+
+- (void)sendEvent:(NSEvent *)event
+{
+    if (event.type == NSEventTypeKeyDown &&
+        [event.charactersIgnoringModifiers isEqualToString:@"\t"] &&
+        (event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask) == NSEventModifierFlagControl)
+        [self.vmview keyDown:event];
+    else
+        [super sendEvent:event];
+}
+
+@end


### PR DESCRIPTION
Added support for Ctrl+Tab to be passed on to the client os (Window switch in Windows VMs)
Ctrl+CMD instead of Ctrl+Alt to release Keyboard and Mouse
CMD+<x,c,v> is handled as Ctrl+<x,c,v> in Windows VMs (Cut, Copy, Paste with Mac Shortcuts)